### PR TITLE
[PDI-13667] - Vertica Bulkloader loads the incorrect hour in a timestamp...

### DIFF
--- a/test-src/org/pentaho/di/verticabulkload/nativebinary/ColumnSpecDateEncodingTest.java
+++ b/test-src/org/pentaho/di/verticabulkload/nativebinary/ColumnSpecDateEncodingTest.java
@@ -1,0 +1,83 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.verticabulkload.nativebinary;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class ColumnSpecDateEncodingTest {
+
+  private ColumnSpec spec;
+  private ByteBuffer buffer;
+
+  @Before
+  public void setUp() throws Exception {
+    buffer = ByteBuffer.allocate( 1024 );
+    buffer.order( ByteOrder.LITTLE_ENDIAN );
+
+    spec = new ColumnSpec( ColumnSpec.ConstantWidthType.DATE );
+    spec.setMainBuffer( buffer );
+  }
+
+  @Test
+  public void dateIsGreaterThanBaseDate() throws Exception {
+    // SELECT DATEDIFF('day', TO_DATE('2000-01-01','YYYY-MM-DD'), TO_DATE('2015-03-20','YYYY-MM-DD'))
+    // -> 5557
+    assertEncodesProperly( "2015-03-20", 5557 );
+  }
+
+  @Test
+  public void dateIsEqualToBaseDate() throws Exception {
+    // SELECT DATEDIFF('day', TO_DATE('2000-01-01','YYYY-MM-DD'), TO_DATE('2000-01-01','YYYY-MM-DD'))
+    // -> 0
+    assertEncodesProperly( "2000-01-01", 0 );
+  }
+
+  @Test
+  public void dateIsLessThanBaseDate() throws Exception {
+    // SELECT DATEDIFF('day', TO_DATE('2000-01-01','YYYY-MM-DD'), TO_DATE('1990-02-28','YYYY-MM-DD'))
+    // -> -3594
+    assertEncodesProperly( "1990-02-28", -3594 );
+  }
+
+  private void assertEncodesProperly( String dt, long expectedValue ) throws Exception {
+    spec.encode( new ValueMetaDate(), parseDate( dt ) );
+    buffer.flip();
+    assertEquals( dt, expectedValue, buffer.getLong() );
+  }
+
+  private static Date parseDate( String str ) throws Exception {
+    return new SimpleDateFormat( "yyyy-MM-dd" ).parse( str );
+  }
+}

--- a/test-src/org/pentaho/di/verticabulkload/nativebinary/ColumnSpecTimeTzEncodingTest.java
+++ b/test-src/org/pentaho/di/verticabulkload/nativebinary/ColumnSpecTimeTzEncodingTest.java
@@ -1,0 +1,134 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.verticabulkload.nativebinary;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.row.value.ValueMetaTimestamp;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static java.util.concurrent.TimeUnit.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class ColumnSpecTimeTzEncodingTest {
+
+  private static final long TODAY_MILLIS = 0;
+
+  private ColumnSpec spec;
+  private ByteBuffer buffer;
+
+  @Before
+  public void setUp() throws Exception {
+    buffer = ByteBuffer.allocate( 1024 );
+    buffer.order( ByteOrder.LITTLE_ENDIAN );
+
+    spec = new ColumnSpec( ColumnSpec.ConstantWidthType.TIMETZ );
+    spec.setMainBuffer( buffer );
+  }
+
+  @Test
+  public void timeInUtc() throws Exception {
+    testTimeIn( "UTC" );
+  }
+
+  @Test
+  public void timeInUtcPlus12() throws Exception {
+    testTimeIn( "Asia/Anadyr" );
+  }
+
+  @Test
+  public void timeInUtcPlus14() throws Exception {
+    testTimeIn( "Pacific/Apia" );
+  }
+
+  @Test
+  public void timeInUtcMinus10() throws Exception {
+    testTimeIn( "US/Hawaii" );
+  }
+
+
+  private void testTimeIn( String tzCode ) throws Exception {
+    TimeZone current = TimeZone.getDefault();
+    try {
+      TimeZone tz = TimeZone.getTimeZone( tzCode );
+      assertNotNull( tzCode, tz );
+      TimeZone.setDefault( tz );
+      assertEncodesProperly( "00:00:00", encodeValue( 0, 0, 0, tz ) );
+    } finally {
+      TimeZone.setDefault( current );
+    }
+  }
+
+  private void assertEncodesProperly( String timestamp, long expectedValue ) throws Exception {
+    Date date = parseTime( timestamp );
+    spec.encode( new ValueMetaTimestamp(), new Timestamp( date.getTime() ) );
+    buffer.flip();
+
+    long actual = buffer.getLong();
+    if ( actual != expectedValue ) {
+      long actualUtc = toUtc( actual );
+      long expectedUtc = toUtc( expectedValue );
+      assertEquals( timestamp, expectedUtc, actualUtc );
+    }
+  }
+
+  private static long encodeValue( int hour, int minute, int second, TimeZone tz ) {
+    long upper40 = HOURS.toMicros( hour ) + MINUTES.toMicros( minute ) + SECONDS.toMicros( second );
+    long lower24 = HOURS.toSeconds( 24 ) + MILLISECONDS.toSeconds( tz.getOffset( TODAY_MILLIS ) );
+    return ( upper40 << 24 ) + lower24;
+  }
+
+  private static long toUtc( long value ) {
+    long lower24 = value & 0xFFFFFF;
+    long upper40 = value >> 24;
+
+    int deltaHours = (int) SECONDS.toHours( lower24 - 24 * 3600 );
+    int hour = (int) MICROSECONDS.toHours( upper40 );
+    upper40 -= HOURS.toMicros( hour );
+    hour -= deltaHours;
+    if ( hour < 0 ) {
+      hour += 24;
+    }
+
+    int minute = (int) MICROSECONDS.toMinutes( upper40 );
+    upper40 -= MINUTES.toMicros( minute );
+
+    int second = (int) MICROSECONDS.toSeconds( upper40 );
+
+    return encodeValue( hour, minute, second, TimeZone.getTimeZone( "UTC" ) );
+  }
+
+  private static Date parseTime( String str ) throws Exception {
+    return new SimpleDateFormat( "HH:mm:ss" ).parse( str );
+  }
+}

--- a/test-src/org/pentaho/di/verticabulkload/nativebinary/ColumnSpecTimestampEncodingTest.java
+++ b/test-src/org/pentaho/di/verticabulkload/nativebinary/ColumnSpecTimestampEncodingTest.java
@@ -1,0 +1,92 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.verticabulkload.nativebinary;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.row.value.ValueMetaTimestamp;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class ColumnSpecTimestampEncodingTest {
+
+  private ColumnSpec spec;
+  private ByteBuffer buffer;
+
+  @Before
+  public void setUp() throws Exception {
+    buffer = ByteBuffer.allocate( 1024 );
+    buffer.order( ByteOrder.LITTLE_ENDIAN );
+
+    spec = new ColumnSpec( ColumnSpec.ConstantWidthType.TIMESTAMP );
+    spec.setMainBuffer( buffer );
+  }
+
+  @Test
+  public void pdi13667() throws Exception {
+    // SELECT TIMESTAMPDIFF ('microsecond',('jan 1, 2000 00:00:00'), ('mar 20, 2015 01:00:00'))
+    // -> 480128400000000
+    assertEncodesProperly( "2015-03-20 01:00:00", 480128400000000L );
+  }
+
+  @Test
+  public void dateIsEarlierThan2000() throws Exception {
+    // SELECT TIMESTAMPDIFF ('microsecond',('jan 1, 2000 00:00:00'), ('feb 28, 1990 02:00:00'))
+    // -> -310514400000000
+    assertEncodesProperly( "1990-02-28 02:00:00", -310514400000000L );
+  }
+
+  @Test
+  public void dateIsEqualToBaseDate() throws Exception {
+    // SELECT TIMESTAMPDIFF ('microsecond',('jan 1, 2000 00:00:00'), ('jan 1, 2000 00:00:00'))
+    // -> 0
+    assertEncodesProperly( "2000-01-01 00:00:00", 0 );
+  }
+
+  @Test
+  public void dateDiffersOnlyInHours() throws Exception {
+    // SELECT TIMESTAMPDIFF ('microsecond',('jan 1, 2000 00:00:00'), ('jan 1, 2000 11:00:00')) "jan 1, 2000 11:00:00"
+    // -> 39600000000
+    assertEncodesProperly( "2000-01-01 11:00:00", 39600000000L );
+  }
+
+  private void assertEncodesProperly( String timestamp, long expectedValue ) throws Exception {
+    Date date = parseDate( timestamp );
+    spec.encode( new ValueMetaTimestamp(), new Timestamp( date.getTime() ) );
+    buffer.flip();
+    assertEquals( timestamp, expectedValue, buffer.getLong() );
+  }
+
+  private static Date parseDate( String str ) throws Exception {
+    return new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss" ).parse( str );
+  }
+}

--- a/test-src/org/pentaho/di/verticabulkload/nativebinary/ColumnSpecTimestampTzEncodingTest.java
+++ b/test-src/org/pentaho/di/verticabulkload/nativebinary/ColumnSpecTimestampTzEncodingTest.java
@@ -1,0 +1,97 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.verticabulkload.nativebinary;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.row.value.ValueMetaTimestamp;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Andrey Khayrutdinov
+ */
+public class ColumnSpecTimestampTzEncodingTest {
+
+  private ColumnSpec spec;
+  private ByteBuffer buffer;
+
+  private Calendar calendar;
+  private long utcJan1of2000;
+
+  @Before
+  public void setUp() throws Exception {
+    buffer = ByteBuffer.allocate( 1024 );
+    buffer.order( ByteOrder.LITTLE_ENDIAN );
+
+    spec = new ColumnSpec( ColumnSpec.ConstantWidthType.TIMESTAMPTZ );
+    spec.setMainBuffer( buffer );
+
+    Calendar utcCalendar = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) );
+    utcCalendar.set( 2000, 0, 1, 0, 0, 0 );
+    utcCalendar.set( Calendar.MILLISECOND, 0 );
+    utcJan1of2000 = utcCalendar.getTimeInMillis();
+
+    calendar = Calendar.getInstance();
+    calendar.clear();
+  }
+
+  @Test
+  public void dateIsGreaterThanBaseDate() throws Exception {
+    calendar.set( 2015, 2, 20 );
+    assertEncodesProperly( "2015-03-20 00:00:00", calendar.getTime() );
+  }
+
+  @Test
+  public void dateIsEqualToBaseDate() throws Exception {
+    calendar.set( 2000, 0, 1 );
+    assertEncodesProperly( "2000-01-01 00:00:00", calendar.getTime() );
+  }
+
+  @Test
+  public void dateIsLessThanBaseDate() throws Exception {
+    calendar.set( 1990, 1, 28 );
+    assertEncodesProperly( "1990-02-28 00:00:00", calendar.getTime() );
+  }
+
+  private void assertEncodesProperly( String timestamp, Date dt ) throws Exception {
+    Date date = parseDate( timestamp );
+    spec.encode( new ValueMetaTimestamp(), new Timestamp( date.getTime() ) );
+    buffer.flip();
+    long expectedValue = TimeUnit.MILLISECONDS.toMicros( dt.getTime() - utcJan1of2000 );
+    assertEquals( timestamp, expectedValue, buffer.getLong() );
+  }
+
+  private static Date parseDate( String str ) throws Exception {
+    return new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss" ).parse( str );
+  }
+}


### PR DESCRIPTION
... field

- change computing value for TIMESTAMP fields
- refactor the rest of date/time types
- add tests for each changed type
(cherry picked from commit e2031d6f0aab059d4310f5588c70d46c35df3db6)

@deinspanjer review it please. This is a backport of https://github.com/pentaho/pentaho-vertica-bulkloader/pull/21