### PR TITLE
PDI-16078 Buffer Overflow in Vertica Bulk Loader

### DIFF
--- a/core/src/main/java/org/pentaho/di/verticabulkload/nativebinary/StreamEncoder.java
+++ b/core/src/main/java/org/pentaho/di/verticabulkload/nativebinary/StreamEncoder.java
@@ -180,8 +180,14 @@ public class StreamEncoder {
     pipedOutputStream.close();
   }
 
+  // There is a potential problem with the way rowMaxSize is being calculated
+  // The junit countMainByteBufferSize() function on 111 and the writeHeader() function
+  // appear to assume different things about the size.  (2*rowMaxSize) takes a conservative
+  // approach to flushing the buffer before it overflows near the boundary (buffer.capacity)
+  // This plugin does not seem to exploit any special byte buffer size alignments or clever
+  // things for performance reasons, so flushing cache earlier is very safe.
   private void checkAndFlushBuffer() throws IOException {
-    if ( buffer.position() + rowMaxSize > buffer.capacity() ) {
+    if ( buffer.position() + (2*rowMaxSize) > buffer.capacity() ) {
       flushBuffer();
     }
   }

--- a/core/src/main/java/org/pentaho/di/verticabulkload/nativebinary/StreamEncoder.java
+++ b/core/src/main/java/org/pentaho/di/verticabulkload/nativebinary/StreamEncoder.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+* Copyright (c) 2002-2017 Pentaho Corporation..  All rights reserved.
 */
 
 package org.pentaho.di.verticabulkload.nativebinary;

--- a/core/src/main/java/org/pentaho/di/verticabulkload/nativebinary/StreamEncoder.java
+++ b/core/src/main/java/org/pentaho/di/verticabulkload/nativebinary/StreamEncoder.java
@@ -187,7 +187,7 @@ public class StreamEncoder {
   // This plugin does not seem to exploit any special byte buffer size alignments or clever
   // things for performance reasons, so flushing cache earlier is very safe.
   private void checkAndFlushBuffer() throws IOException {
-    if ( buffer.position() + (2*rowMaxSize) > buffer.capacity() ) {
+    if ( buffer.position() + ( 2 * rowMaxSize ) > buffer.capacity() ) {
       flushBuffer();
     }
   }


### PR DESCRIPTION
Made the checking for buffer room for a new row more conservative because of a lack of precision in calculating a row's maximum size.

Also since no optimizations for writing to the channel appear present, it seems perfectly safe to flush the buffer a bit early and avoid random nio overflows near capacity.